### PR TITLE
EPBDS-13521 Fix NLS class loader leak by storing Locale in thread-local

### DIFF
--- a/org.eclipse.jgit.lfs/src/org/eclipse/jgit/lfs/LfsPrePushHook.java
+++ b/org.eclipse.jgit.lfs/src/org/eclipse/jgit/lfs/LfsPrePushHook.java
@@ -13,7 +13,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.eclipse.jgit.lfs.Protocol.*;
 import static org.eclipse.jgit.lfs.internal.LfsConnectionFactory.toRequest;
 import static org.eclipse.jgit.transport.http.HttpConnection.HTTP_OK;
-import static org.eclipse.jgit.transport.http.HttpConnection.HTTP_CREATED;
 import static org.eclipse.jgit.util.HttpSupport.*;
 
 import java.io.IOException;

--- a/org.eclipse.jgit.test/tst/org/eclipse/jgit/nls/NLSTest.java
+++ b/org.eclipse.jgit.test/tst/org/eclipse/jgit/nls/NLSTest.java
@@ -11,8 +11,11 @@
 package org.eclipse.jgit.nls;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Field;
 import java.util.Locale;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
@@ -25,6 +28,48 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 public class NLSTest {
+
+	/**
+	 * Tomcat's leak detector flags any thread-local value whose class was
+	 * loaded by the web-application class loader. After a thread runs a git
+	 * operation, the value it leaves in NLS's thread-local must be a
+	 * {@link Locale} (bootstrap-loaded), never an {@link NLS} instance, so the
+	 * web-application class loader is not retained. See Eclipse bug 550529.
+	 */
+	@Test
+	public void testNoNLSValueRetainedOnWorkerThread()
+			throws InterruptedException, ExecutionException {
+		ExecutorService pool = Executors.newSingleThreadExecutor();
+		try {
+			Future<Object> retained = pool.submit(() -> {
+				NLS.setLocale(Locale.GERMAN);
+				GermanTranslatedBundle.get();
+				return threadLocalValue();
+			});
+			Object value = retained.get();
+			assertFalse(
+					"worker thread must not retain an NLS value in its thread-local",
+					value instanceof NLS);
+			assertTrue(
+					"worker thread must retain only a Locale in its thread-local",
+					value instanceof Locale);
+		} finally {
+			pool.shutdown();
+			pool.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
+		}
+	}
+
+	/**
+	 * Returns the value the calling thread currently holds in NLS's private
+	 * thread-local. Reflecting on NLS (an application class) is permitted by the
+	 * module system, unlike reflecting on {@link Thread}'s internal maps.
+	 */
+	private static Object threadLocalValue() throws ReflectiveOperationException {
+		Field localField = NLS.class.getDeclaredField("local");
+		localField.setAccessible(true);
+		ThreadLocal<?> local = (ThreadLocal<?>) localField.get(null);
+		return local.get();
+	}
 
 	@Test
 	public void testNLSLocale() {

--- a/org.eclipse.jgit/src/org/eclipse/jgit/nls/GlobalBundleCache.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/nls/GlobalBundleCache.java
@@ -26,10 +26,9 @@ import org.eclipse.jgit.errors.TranslationStringMissingException;
  * (same locale and type) from the same or a different thread will return the
  * cached one.
  * <p>
- * Note that NLS instances maintain per-thread Map of loaded translation
- * bundles. Once a thread accesses a translation bundle it will keep reference
- * to it and will not call {@link #lookupBundle(Locale, Class)} again for the
- * same translation bundle as long as its locale doesn't change.
+ * This static cache is the only place translation bundles are retained;
+ * {@link NLS} stores only a {@link Locale} per thread and resolves bundles
+ * through {@link #lookupBundle(Locale, Class)} on every call.
  */
 class GlobalBundleCache {
 	private static final Map<Locale, Map<Class, TranslationBundle>> cachedBundles

--- a/org.eclipse.jgit/src/org/eclipse/jgit/nls/NLS.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/nls/NLS.java
@@ -11,8 +11,6 @@
 package org.eclipse.jgit.nls;
 
 import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jgit.errors.TranslationBundleLoadingException;
 import org.eclipse.jgit.errors.TranslationStringMissingException;
@@ -42,7 +40,16 @@ public class NLS {
 	 */
 	public static final Locale ROOT_LOCALE = new Locale("", "", ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
-	private static final InheritableThreadLocal<NLS> local = new InheritableThreadLocal<>();
+	/**
+	 * The per-thread locale. Only a {@link Locale} (loaded by the bootstrap
+	 * class loader) is stored here, never an {@code NLS} instance, so that a
+	 * thread which touches NLS does not retain the class loader that loaded the
+	 * {@code NLS} class. This matters in servlet containers, where retaining the
+	 * web-application class loader on a long-lived container thread is a memory
+	 * leak (see Eclipse bug 550529). The actual translation bundles are held by
+	 * the static {@link GlobalBundleCache}, which {@link #clear()} releases.
+	 */
+	private static final InheritableThreadLocal<Locale> local = new InheritableThreadLocal<>();
 
 	/**
 	 * Sets the locale for the calling thread.
@@ -56,7 +63,7 @@ public class NLS {
 	 *            the preferred locale
 	 */
 	public static void setLocale(Locale locale) {
-		local.set(new NLS(locale));
+		local.set(locale);
 	}
 
 	/**
@@ -66,15 +73,7 @@ public class NLS {
 	 * <code>NLS.setLocale(Locale.getDefault())</code>.
 	 */
 	public static void useJVMDefaultLocale() {
-		useJVMDefaultInternal();
-	}
-
-	// TODO(ms): change signature of public useJVMDefaultLocale() in 5.0 to get
-	// rid of this internal method
-	private static NLS useJVMDefaultInternal() {
-		NLS b = new NLS(Locale.getDefault());
-		local.set(b);
-		return b;
+		local.remove();
 	}
 
 	/**
@@ -96,11 +95,11 @@ public class NLS {
 	 *                {@link org.eclipse.jgit.errors.TranslationStringMissingException}
 	 */
 	public static <T extends TranslationBundle> T getBundleFor(Class<T> type) {
-		NLS b = local.get();
-		if (b == null) {
-			b = useJVMDefaultInternal();
+		Locale locale = local.get();
+		if (locale == null) {
+			locale = Locale.getDefault();
 		}
-		return b.get(type);
+		return GlobalBundleCache.lookupBundle(locale, type);
 	}
 
 	/**
@@ -112,25 +111,10 @@ public class NLS {
 		GlobalBundleCache.clear();
 	}
 
-	private final Locale locale;
-
-	private final Map<Class, TranslationBundle> map = new ConcurrentHashMap<>();
-
-	private NLS(Locale locale) {
-		this.locale = locale;
-	}
-
-	@SuppressWarnings("unchecked")
-	private <T extends TranslationBundle> T get(Class<T> type) {
-		TranslationBundle bundle = map.get(type);
-		if (bundle == null) {
-			bundle = GlobalBundleCache.lookupBundle(locale, type);
-			// There is a small opportunity for a race, which we may
-			// lose. Accept defeat and return the winner's instance.
-			TranslationBundle old = map.putIfAbsent(type, bundle);
-			if (old != null)
-				bundle = old;
-		}
-		return (T) bundle;
+	private NLS() {
+		// This class is not intended to be instantiated; it only holds static
+		// state. A private constructor keeps it from being subclassed or
+		// instantiated, and ensures no NLS instance is ever stored in the
+		// thread-local (see {@link #local}).
 	}
 }


### PR DESCRIPTION
Thank you for contributing to JGit!

JGit uses [GerritHub](https://eclipse.gerrithub.io) for code changes and review, therefore **pull requests in this repository cannot be merged**.

Please make sure you have read the section on [contributing patches](https://github.com/eclipse-egit/egit/wiki/Contributor-Guide#contributing-patches) of the [Contributor Guide](https://github.com/eclipse-egit/egit/wiki/Contributor-Guide).